### PR TITLE
Always use test Python when creating test TensorBoard sessions

### DIFF
--- a/src/test/tensorBoard/tensorBoardSession.test.ts
+++ b/src/test/tensorBoard/tensorBoardSession.test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import Sinon, * as sinon from 'sinon';
+import { SemVer } from 'semver';
 import { IApplicationShell, ICommandManager } from '../../client/common/application/types';
 import { IExperimentService, IInstaller, InstallerResponse, ProductInstallStatus } from '../../client/common/types';
 import { TensorBoard } from '../../client/common/utils/localize';
@@ -11,7 +12,6 @@ import { closeActiveWindows, initialize } from '../initialize';
 import * as ExperimentHelpers from '../../client/common/experiments/helpers';
 import { DiscoveryVariants } from '../../client/common/experiments/groups';
 import { IInterpreterService } from '../../client/interpreter/contracts';
-import { SemVer } from 'semver';
 import { Architecture } from '../../client/common/utils/platform';
 import { PythonEnvironment, EnvironmentType } from '../../client/pythonEnvironments/info';
 import { PYTHON_PATH } from '../common';

--- a/src/test/tensorBoard/tensorBoardSession.test.ts
+++ b/src/test/tensorBoard/tensorBoardSession.test.ts
@@ -10,6 +10,23 @@ import { TensorBoardSessionProvider } from '../../client/tensorBoard/tensorBoard
 import { closeActiveWindows, initialize } from '../initialize';
 import * as ExperimentHelpers from '../../client/common/experiments/helpers';
 import { DiscoveryVariants } from '../../client/common/experiments/groups';
+import { IInterpreterService } from '../../client/interpreter/contracts';
+import { SemVer } from 'semver';
+import { Architecture } from '../../client/common/utils/platform';
+import { PythonEnvironment, EnvironmentType } from '../../client/pythonEnvironments/info';
+import { PYTHON_PATH } from '../common';
+
+const info: PythonEnvironment = {
+    architecture: Architecture.Unknown,
+    companyDisplayName: '',
+    displayName: '',
+    envName: '',
+    path: '',
+    envType: EnvironmentType.Unknown,
+    version: new SemVer('0.0.0-alpha'),
+    sysPrefix: '',
+    sysVersion: '',
+};
 
 suite('TensorBoard session creation', async () => {
     let serviceManager: IServiceManager;
@@ -38,6 +55,14 @@ suite('TensorBoard session creation', async () => {
         // These are used in interpreter service
         inExperimentStub.withArgs(DiscoveryVariants.discoverWithFileWatching).resolves(false);
         inExperimentStub.withArgs(DiscoveryVariants.discoveryWithoutFileWatching).resolves(false);
+
+        const interpreter: PythonEnvironment = {
+            ...info,
+            envType: EnvironmentType.Unknown,
+            path: PYTHON_PATH,
+        };
+        const interpreterService = serviceManager.get<IInterpreterService>(IInterpreterService);
+        sandbox.stub(interpreterService, 'getActiveInterpreter').resolves(interpreter);
 
         // Create tensorboard session provider
         provider = serviceManager.get<TensorBoardSessionProvider>(TensorBoardSessionProvider);


### PR DESCRIPTION
It looks like your PR may have introduced a behavior change on Ubuntu for autoselecting the active interpreter, so when we ran the test:
1. the interpreter was not set, 
2. we displayed the quickpick asking the user to set the interpreter, which timed out
3. this caused session creation to fail 

Here I'm doing what we do for other such tests, i.e. force the test to use the CI Python as its active interpreter.
https://github.com/microsoft/vscode-python/blob/adfa0ab9900b222912c9f0538a0b4f183d94a581/src/test/common/moduleInstaller.test.ts#L515-L517

With this change the test passes (although I did merge main for that test run due to merge conflicts in order to get a full run, and I'm not sure I resolved the conflicts entirely correctly):
https://github.com/joyceerhl/vscode-python/runs/1779568668?check_suite_focus=true